### PR TITLE
Fixs for Bibtext 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-/_build
+# Exclude documentation build directories
+**/_build
+
+# Exclude MacOS nuisance files
+.DS_Store

--- a/cdmi_extensions/capabilities_selection/conf.py
+++ b/cdmi_extensions/capabilities_selection/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/cdmi_extensions/cors/conf.py
+++ b/cdmi_extensions/cors/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/cdmi_extensions/data_affinity/conf.py
+++ b/cdmi_extensions/data_affinity/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/cdmi_extensions/extended_child_listing/conf.py
+++ b/cdmi_extensions/extended_child_listing/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/cdmi_extensions/jobs/conf.py
+++ b/cdmi_extensions/jobs/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/cdmi_extensions/partial_upload/conf.py
+++ b/cdmi_extensions/partial_upload/conf.py
@@ -34,8 +34,7 @@ from string import Template
 # ones.
 extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinxcontrib.bibtex']
+    'sphinx.ext.coverage']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/conf.py
+++ b/conf.py
@@ -37,6 +37,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinxcontrib.bibtex']
 
+bibtex_bibfiles = ['references/refs.bib']
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
Bibtext 2.0 broke the Sphinx build process. This removes bibtext from extensions, and adds the newly required reference to the config file for the main CDMI spec.

Also updates the .gitignore to ignore build directories in subdirectories.